### PR TITLE
Update Samples to reflect breaking Nuget Release for OSIsoft.OMFIngress

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # Version History
-## 1.1.11 / 2021-06-09
+
+## 1.1.11 / 2021-07-08
 
 - Updated dependencies, OSIsoft.OMFIngress removed ISDS Parameter
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 # Version History
+## 1.1.11 / 2021-06-09
+
+- Updated dependencies, OSIsoft.OMFIngress removed ISDS Parameter
 
 ## 1.1.10 / 2021-06-09
 

--- a/OmfIngressClientLibraries/Device.cs
+++ b/OmfIngressClientLibraries/Device.cs
@@ -16,7 +16,7 @@ namespace OmfIngressClientLibraries
             // Create the AuthenticationHandler and IngressSerice to use to send data
             AuthenticationHandler deviceAuthenticationHandler = new AuthenticationHandler(new Uri(address), clientId, clientSecret);
 
-            OmfIngressService deviceBaseOmfIngressService = new OmfIngressService(new Uri(address), null, HttpCompressionMethod.None, deviceAuthenticationHandler);
+            OmfIngressService deviceBaseOmfIngressService = new OmfIngressService(new Uri(address), HttpCompressionMethod.None, deviceAuthenticationHandler);
             _deviceOmfIngressService = deviceBaseOmfIngressService.GetOmfIngressService(tenantId, namespaceId);
         }
 

--- a/OmfIngressClientLibraries/OmfIngressClient.cs
+++ b/OmfIngressClientLibraries/OmfIngressClient.cs
@@ -20,7 +20,7 @@ namespace OmfIngressClientLibraries
             AuthenticationHandler authenticationHandler = new AuthenticationHandler(new Uri(address), clientId, clientSecret);
             _tenantId = tenantId;
             _namespaceId = namespaceId;
-            OmfIngressService baseOmfIngressService = new OmfIngressService(new Uri(address), null, HttpCompressionMethod.None, authenticationHandler);
+            OmfIngressService baseOmfIngressService = new OmfIngressService(new Uri(address), HttpCompressionMethod.None, authenticationHandler);
             _omfIngressService = baseOmfIngressService.GetOmfIngressService(tenantId, namespaceId);
         }
 

--- a/OmfIngressClientLibraries/OmfIngressClientLibraries.csproj
+++ b/OmfIngressClientLibraries/OmfIngressClientLibraries.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="OSIsoft.OmfIngress" Version="4.0.0-prerelease-20200512.1" />
+    <PackageReference Include="OSIsoft.OmfIngress" Version="5.0.0-prerelease-20210707.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OMF Ingress .NET Samples
 
-**Version:** 1.1.10
+**Version:** 1.1.11
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/OCS/osisoft.sample-ocs-omf_ingress-dotnet?repoName=osisoft%2Fsample-ocs-omf_ingress-dotnet&branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2620&repoName=osisoft%2Fsample-ocs-omf_ingress-dotnet&branchName=main)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following code block illustrates how to configure the OmfIngressService to u
 ```C#
 AuthenticationHandler authenticationHandler = new AuthenticationHandler(address, clientId, clientSecret);
 
-OmfIngressService baseOmfIngressService = new OmfIngressService(new Uri(address), null, HttpCompressionMethod.None, authenticationHandler);
+OmfIngressService baseOmfIngressService = new OmfIngressService(new Uri(address), HttpCompressionMethod.None, authenticationHandler);
 IOmfIngressService omfIngressService = baseOmfIngressService.GetOmfIngressService(tenantId, namespaceId);
 ```
 


### PR DESCRIPTION
Recently we have released a new version of our public nuget package to be 5.0.0. I am updating the samples on behalf of the work item listed here: https://dev.azure.com/osieng/engineering/_sprints/taskboard/Parse/engineering/2021/Q3/2021.07.07?workitem=90897